### PR TITLE
Mixtrack3: add option for Library navigation mode: Focus | Classic

### DIFF
--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -188,6 +188,13 @@ var PADcolors = {
     "purple": 127
 };
 
+// Two modes for the library controls
+const libraryModes = {
+    focus: 0,
+    classic: 1,
+};
+const LibraryMode = libraryModes[engine.getSetting("libraryMode")] || libraryModes.focus;
+
 // Utilities
 // =====================================================================
 
@@ -1084,14 +1091,24 @@ NumarkMixtrack3.BrowseButton = function(channel, control, value, status, group) 
     );
 
     if (value === ON) {
-	    if (shifted) {
-	        // SHIFT + BROWSE push : maximize/minimize library view
-	        script.toggleControl("[Skin]", "show_maximized_library");
-	    } else {
-	        // Browse push : expand sidebar item or load track when in track table
-	        engine.setValue("[Library]", "GoToItem", true);
-	        }
-	    }
+        if (LibraryMode === libraryModes.classic) {
+            if (shifted) {
+                // SHIFT + BROWSE push : maximize/minimize library view
+                script.toggleControl("[Skin]", "show_maximized_library");
+            } else {
+                // Browse push : expand sidebar item or load track when in track table
+                engine.setValue("[Library]", "GoToItem", true);
+            }
+        } else { // Classic mode
+            if (shifted) {
+                // SHIFT + BROWSE push : directory mode -- > Open/Close selected side bar item
+                engine.setValue("[Library]", "GoToItem", true);
+            } else {
+                // Browse push : maximize/minimize library view
+                script.toggleControl("[Skin]", "show_maximized_library");
+            }
+        }
+    }
 };
 
 NumarkMixtrack3.BrowseKnob = function(channel, control, value, status, group) {
@@ -1103,11 +1120,20 @@ NumarkMixtrack3.BrowseKnob = function(channel, control, value, status, group) {
     // value = 1 / 2 / 3 ... for positive //value = 1 / 2 / 3
     var nval = (value > 0x40 ? value - 0x80 : value);
 
-    // SHIFT+Turn BROWSE Knob : change focus between search, track table, and sidebar
-    if (shifted) {
-        engine.setValue("[Library]", "MoveFocus", nval);
-    } else {
-        engine.setValue("[Library]", "MoveVertical", nval);
+    if (LibraryMode === libraryModes.focus) {
+        // SHIFT+Turn BROWSE Knob : change focus between search, track table, and sidebar
+        if (shifted) {
+            engine.setValue("[Library]", "MoveFocus", nval);
+        } else {
+            engine.setValue("[Library]", "MoveVertical", nval);
+        }
+    } else { // Classic mode
+        // SHIFT+Turn BROWSE Knob : directory mode --> select Play List/Side bar item
+        if (shifted) {
+            engine.setValue("[Playlist]", "SelectPlaylist", nval);
+        } else {
+            engine.setValue("[Playlist]", "SelectTrackKnob", nval);
+        }
     }
 };
 

--- a/res/controllers/Numark-Mixtrack-3.midi.xml
+++ b/res/controllers/Numark-Mixtrack-3.midi.xml
@@ -8,6 +8,24 @@
         <forums>https://mixxx.discourse.group/t/mixtrack-pro-3/15165</forums>
         <wiki>http://www.mixxx.org/wiki/doku.php/numark_mixtrack_pro_3</wiki>
     </info>
+    <settings>
+        <group label="Library navigation">
+            <option
+                variable="libraryMode"
+                label="Navigation mode"
+                type="enum">
+                <value label="Focus" default="true">focus</value>
+                <value label="Classic">classic</value>
+                <description>
+                    In Focus mode the Browse encoder affects the library widget which currently has keyboard focus.
+                    This requires the Mixxx window to have focus and allows to control the searchbar, too.
+
+                    In Classic mode the Browse encoder can select items in the sidebar and tracks table only, but independent
+                    of keyboadr focus.
+                </description>
+            </option>
+        </group>
+    </settings>
     <controller id="Mixtrack3">
         <scriptfiles>
             <file functionprefix="NumarkMixtrack3" filename="Numark-Mixtrack-3-scripts.js" />


### PR DESCRIPTION
This adds controller preferences on top of https://github.com/mixxxdj/mixxx/pull/14180 to allow users to choose between the focus and classic library navigation.
I think the new behavior is a somewhat 'breaking change', and this is a good minimal example for controller preferences.

Please test if this works:
in the controller settings page there should now be an option for the Library navigation

What do you think?